### PR TITLE
ci(renovate): Update package-lock.json after OpenUI5 is updated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,7 +69,12 @@
 			"minimumReleaseAge": null,
 			"schedule": [
 				"* 8-16 * * 1"
-			]
+			],
+			"postUpgradeTasks": {
+				"commands": ["npm install"],
+				"fileFilters": ["package-lock.json"],
+				"executionMode": "branch"
+			}
 		}
 	]
 }


### PR DESCRIPTION
WIP: This requires `allowedPostUpgradeCommands` includes `["^npm install$"]` in the bot's global/admin config. Otherwise the command will be silently skipped.

JIRA: CPOUI5FOUNDATION-1356