### PR TITLE
ci(renovate): Re-arrange OpenUI5 types handling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,20 +5,7 @@
 		"github>ui5/renovate-config:lts#v1.2.1"
 	],
 	"ignorePresets": [":ignoreModulesAndTests", ":pinDevDependencies"],
-	"ignoreDeps": ["node", "npm", "@types/qunit", "@openui5/types"],
-	"customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "**/package.json"
-      ],
-      "matchStrings": [
-        "\"@openui5/types\":\\s*\"(?<currentValue>[\\d.]+)\""
-      ],
-      "depNameTemplate": "openui5_types",
-      "datasourceTemplate": "custom.openui5_lts"
-    }
-  ],
+	"ignoreDeps": ["node", "npm", "@types/qunit"],
 	"minimumReleaseAge": "3 days",
 	"rangeStrategy": "replace",
 	"prCreation": "immediate",
@@ -59,8 +46,15 @@
 		},
 		{
 			"matchDepNames": [
+				"@openui5/types"
+			],
+			"overrideDatasource": "custom.openui5_lts",
+			"overridePackageName": "openui5_types"
+		},
+		{
+			"matchDepNames": [
 				"openui5_lts",
-				"openui5_types"
+				"@openui5/types"
 			],
 			"automerge": false,
 			"groupName": "openui5",


### PR DESCRIPTION
Improves the handling of OpenUI5 types in Renovate update PRs. Replaces the existing approach with a simpler configuration that overrides the datasource for the `@openui5/types` package.

JIRA: CPOUI5FOUNDATION-1356