### PR TITLE
ci(renovate.json): Remove "overridePackageName" property

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,8 +48,7 @@
 			"matchDepNames": [
 				"@openui5/types"
 			],
-			"overrideDatasource": "custom.openui5_lts",
-			"overridePackageName": "openui5_types"
+			"overrideDatasource": "custom.openui5_lts"
 		},
 		{
 			"matchDepNames": [


### PR DESCRIPTION
This property is not required, so can be removed.